### PR TITLE
Step 07 - Added format duration helper

### DIFF
--- a/app/helpers/format-duration.js
+++ b/app/helpers/format-duration.js
@@ -1,0 +1,21 @@
+import Ember from 'ember'
+
+export function formatDuration(secondsQuantity) {
+  if (secondsQuantity == null) { 
+    return '';
+  }
+
+  return minutes(secondsQuantity) + ':' + seconds(secondsQuantity);
+}
+
+function seconds(secondsQuantity) {
+  const seconds = secondsQuantity % 60;
+  
+  return (seconds < 10) ? '0' + seconds : seconds
+}
+
+function minutes(secondsQuantity) {
+  return Math.floor(secondsQuantity / 60);
+}
+
+export default Ember.Helper.helper(formatDuration);

--- a/app/templates/album.hbs
+++ b/app/templates/album.hbs
@@ -11,7 +11,7 @@
         <span class="track-number">{{song.track}}</span>
       </td>
       <td class="song-name">{{song.name}}</td>
-      <td class="song-duration">{{song.duration}}</td>
+      <td class="song-duration">{{format-duration song.duration}}</td>
     </tr>
   {{/each}}
   <tr>


### PR DESCRIPTION
In the Ember course version, the helper must be exported in a different way: 

``` js
export default Ember.Handlebars.makeBoundHelper(formatDuration);
```
