### PR TITLE
Step 10 - Created "player" service

### DIFF
--- a/app/components/song-row.js
+++ b/app/components/song-row.js
@@ -5,12 +5,16 @@ export default Ember.Component.extend({
 
   isPlaying: false,
 
+  player: Ember.inject.service(),
+
   actions: {
     play: function() {
+      this.get('player').play(this.get('song'));
       this.set('isPlaying', true);
     },
 
     pause: function() {
+      this.get('player').pause();
       this.set('isPlaying', false);
     }
   }

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -9,8 +9,6 @@ export default Ember.Service.extend({
 
   setupAudioElement: function() {
     var el = document.createElement('audio');
-    el.addEventListener('play', run.bind(this, 'didStartPlaying'));
-    el.addEventListener('pause', run.bind(this, 'didPause'));
     
     this.set('audioElement', el);
   }.on('init'),
@@ -18,18 +16,12 @@ export default Ember.Service.extend({
   play: function(song) {
     this.set('audioElement.src', song.get('url'));
     this.get('audioElement').play();
+    this.set('isPlaying', true);
   },
 
   pause: function() {
     this.get('audioElement').pause();
     this.set('audioElement.src', '');
-  },
-
-  didStartPlaying: function() {
-    this.set('isPlaying', true);
-  },
-
-  didPause: function() {
     this.set('isPlaying', false);
   },
 

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -9,8 +9,6 @@ export default Ember.Service.extend({
 
   setupAudioElement: function() {
     var el = document.createElement('audio');
-    el.addEventListener('play', run.bind(this, 'didStartPlaying'));
-    el.addEventListener('pause', run.bind(this, 'didPause'));
     
     this.set('audioElement', el);
   }.on('init'),
@@ -18,22 +16,17 @@ export default Ember.Service.extend({
   play: function(song) {
     this.set('audioElement.src', song.get('url'));
     this.get('audioElement').play();
+    this.set('isPlaying', true);
   },
 
   pause: function() {
     this.get('audioElement').pause();
     this.set('audioElement.src', '');
-  },
-
-  didStartPlaying: function() {
-    this.set('isPlaying', true);
-  },
-
-  didPause: function() {
     this.set('isPlaying', false);
   },
 
   willDestroy: function() {
-    this.pause();
+    this.get('audioElement').pause();
+    this.set('audioElement.src', '');
   },
 })

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 
-//try to change this
 let run = Ember.run;
 
 export default Ember.Service.extend({
@@ -12,6 +11,7 @@ export default Ember.Service.extend({
     var el = document.createElement('audio');
     el.addEventListener('play', run.bind(this, 'didStartPlaying'));
     el.addEventListener('pause', run.bind(this, 'didPause'));
+    
     this.set('audioElement', el);
   }.on('init'),
 

--- a/app/services/player.js
+++ b/app/services/player.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+//try to change this
+let run = Ember.run;
+
+export default Ember.Service.extend({
+  isPlaying: false,
+
+  audioElement: null,
+
+  setupAudioElement: function() {
+    var el = document.createElement('audio');
+    el.addEventListener('play', run.bind(this, 'didStartPlaying'));
+    el.addEventListener('pause', run.bind(this, 'didPause'));
+    this.set('audioElement', el);
+  }.on('init'),
+
+  play: function(song) {
+    this.set('audioElement.src', song.get('url'));
+    this.get('audioElement').play();
+  },
+
+  pause: function() {
+    this.get('audioElement').pause();
+    this.set('audioElement.src', '');
+  },
+
+  didStartPlaying: function() {
+    this.set('isPlaying', true);
+  },
+
+  didPause: function() {
+    this.set('isPlaying', false);
+  },
+
+  willDestroy: function() {
+    this.pause();
+  },
+})

--- a/tests/acceptance/step-10-test.js
+++ b/tests/acceptance/step-10-test.js
@@ -30,8 +30,9 @@ test("Eventually isPlaying changes when the song is played", function() {
   expect(1);
   var song = Ember.Object.create({url: 'audio/Southern_Nights_-_07_-_All_My_Sorrows.mp3'});
 
-  propertyShouldBecome(player, 'isPlaying', true);
   player.play(song);
+
+  equal(player.get('isPlaying'), true, 'isPlaying property is set to true');  
 });
 
 test("The song stops playing when the service is destroyed", function() {
@@ -55,10 +56,12 @@ test("Eventually isPlaying becomes false when the song is paused", function() {
   var song = Ember.Object.create({url: 'audio/Southern_Nights_-_07_-_All_My_Sorrows.mp3'});
 
   player.play(song);
-  propertyShouldBecome(player, 'isPlaying', true);
+
+  equal(player.get('isPlaying'), true, 'isPlaying property is set to true');
 
   player.pause();
-  return propertyShouldBecome(player, 'isPlaying', false);
+
+  equal(player.get('isPlaying'), false, 'isPlaying property is set to false');
 });
 
 test("Clicking the song-row pause button pauses the player", function() {


### PR DESCRIPTION
5th and 6th tests of this module were not working with the implementation suggested by the course.

Putting a `debugger` in `didPause` callback function, it seems this function is not being called.

To solve this problem It was needed to remove audio element callbacks to set `isPlaying` property and set this property directly on `play` and `pause` functions. Besides that it was necessary to change test implementation. Those changes can be seen in the commit below:

https://github.com/regishideki/bumbox/pull/11/commits/43348e2359e50b65eb1d65915e89b2d119005533